### PR TITLE
Bundle update 2017 11 24 with jekyll-toc v0.5.0.rc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :jekyll_plugins do
   gem 'jekyll-sitemap'
   gem 'jekyll-tagging'
   gem 'jekyll-tagging-related_posts'
-  gem 'jekyll-toc'
+  gem 'jekyll-toc', '0.5.0.rc'
   gem 'jemoji'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ end
 
 group :development do
   gem 'rake'
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    coderay (1.1.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -57,7 +58,7 @@ GEM
     jekyll-tagging-related_posts (1.0.0)
       jekyll (~> 3.0)
       jekyll-tagging (~> 1.0)
-    jekyll-toc (0.4.0)
+    jekyll-toc (0.5.0.rc)
       nokogiri (~> 1.6)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
@@ -72,6 +73,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    method_source (0.9.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     nokogiri (1.8.1)
@@ -79,6 +81,9 @@ GEM
     nuggets (1.5.0)
     pathutil (0.16.0)
       forwardable-extended (~> 2.6)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.1)
     rake (12.3.0)
     rb-fsevent (0.10.2)
@@ -107,10 +112,10 @@ DEPENDENCIES
   jekyll-sitemap
   jekyll-tagging
   jekyll-tagging-related_posts
-  jekyll-toc
+  jekyll-toc (= 0.5.0.rc)
   jemoji
+  pry
   rake
 
-
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     pathutil (0.16.0)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.1)
-    rake (12.2.1)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)

--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,10 @@ tag_page_dir: tag
 tag_page_layout: tag_page
 tag_permalink_style: pretty
 
+toc:
+  min_level: 1
+  max_level: 4
+
 # jekyll-compose
 post_front_matter:
   image: /images/posts/


### PR DESCRIPTION
**Updated RubyGems:**

- Updated: [rake](https://github.com/ruby/rake), [12.2.1...12.3.0](https://github.com/ruby/rake/compare/v12.2.1...v12.3.0) ([CHANGELOG](https://github.com/ruby/rake/blob/master/History.rdoc))
- jekyll-toc