### PR TITLE
Jekyll 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.bundle
 /vendor
 /.jekyll-metadata
+/.jekyll-cache

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
+gem 'jekyll', '4.0.0.pre.beta1'
 
 group :jekyll_plugins do
-  # gem 'jekyll-admin'
   gem 'jekyll-coffeescript'
   gem 'jekyll-compose'
   gem 'jekyll-feed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,20 +27,21 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.6.0)
-    i18n (0.9.5)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.6)
+    jekyll (4.0.0.pre.beta1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (~> 0.7)
+      i18n (>= 0.9.5, < 2)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
+      rouge (~> 3.0)
       safe_yaml (~> 1.0)
     jekyll-coffeescript (1.2.2)
       coffee-script (~> 2.2)
@@ -67,7 +68,9 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    kramdown (1.17.0)
+    kramdown (2.1.0)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     liquid (4.0.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -106,7 +109,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll
+  jekyll (= 4.0.0.pre.beta1)
   jekyll-coffeescript
   jekyll-compose
   jekyll-feed


### PR DESCRIPTION
[Jekyll 4.0.0.pre.beta1 Released | Jekyll • Simple, blog-aware, static sites](https://jekyllrb.com/news/2019/08/04/jekyll-4-0-0-pre-beta1-released/)