### PR TITLE
Enable Disqus comment form again

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -70,7 +70,6 @@ layout: default
   {% endif %}
 </div>
 
-{% comment %}
 <div id="disqus_thread"></div>
 <script>
 var disqus_config = function () {
@@ -79,13 +78,12 @@ this.page.identifier = "{{ page.url }}";
 };
 (function () { // DON'T EDIT BELOW THIS LINE
   var d = document, s = d.createElement('script');
-  s.src = 'https://hackyourdesign.disqus.com/embed.js';
+  s.src = 'https://hack-your-design.disqus.com/embed.js';
   s.setAttribute('data-timestamp', +new Date());
   (d.head || d.body).appendChild(s);
 })();
 </script>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-{% endcomment %}
 
 <div id="adsense">
   <!-- post-rectangle1 -->


### PR DESCRIPTION
Since ads are enabled on my old Disqus account and can't be disabled,
so I use another Disqus account and remove the ads.

(Although the comments stored on my old account are disappeared :p )