### PR TITLE
fix: Use flex for categories / Centering post image

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ toc:
   max_level: 4
 # tagging
 tag_page_dir: tag
-tag_page_layout: tag_page
+tag_page_layout: category
 tag_permalink_style: pretty
 # jekyll-compose
 jekyll_compose:

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -5,7 +5,6 @@ layout: default
 <div>
   <div class="space-y-2 pb-8 pt-6 md:space-y-5">
     <h1 class="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
-      {{ page.title }}
       {{ page.tag }}
     </h1>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,7 @@ layout: default
       {% include tags.html tags=page.tags %}
     </div>
     {% if page.image and page.hideimage != true %}
-    <div>
+    <div class="flex justify-center">
       <img src="{{ page.image }}" alt="(image){{ page.title }}" title="{{ page.title }}">
     </div>
     {% endif %}

--- a/assets/css/output.css
+++ b/assets/css/output.css
@@ -1487,6 +1487,10 @@ video {
   justify-content: space-between;
 }
 
+.gap-2 {
+  gap: 0.5rem;
+}
+
 .space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
   margin-right: calc(1rem * var(--tw-space-x-reverse));

--- a/categories.html
+++ b/categories.html
@@ -11,6 +11,8 @@ title: Categories
   </div>
 
   <div class="prose prose-xl">
-    {% include_cached tag_cloud.html %}
+    <div class="flex flex-wrap gap-2">
+      {% include_cached tag_cloud.html %}
+    </div>
   </div>
 </div>


### PR DESCRIPTION

| Before | After |
|---|---|
| ![CleanShot 2024-09-23 at 11 04 26@2x](https://github.com/user-attachments/assets/b0a003c2-d716-4d40-8929-b31f55626199) | ![CleanShot 2024-09-23 at 11 04 47@2x](https://github.com/user-attachments/assets/0395a326-84b5-4cfd-8d35-d0cec144691b) | 
| ![CleanShot 2024-09-23 at 11 05 13@2x](https://github.com/user-attachments/assets/e281ddc5-0010-43b7-9f22-acb616bebdbe) | ![CleanShot 2024-09-23 at 11 05 34@2x](https://github.com/user-attachments/assets/6cde74bb-139d-41dd-bc48-adb55c3416fb) | 
