### PR TITLE
chore: Update style for `code`

### DIFF
--- a/assets/css/output.css
+++ b/assets/css/output.css
@@ -1067,6 +1067,13 @@ video {
   margin-bottom: 0;
 }
 
+.prose :where(code.language-plaintext):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: inherit;
+  padding: 0.125rem;
+  border-radius: 0.25rem;
+  background-color: #f3f4f6;
+}
+
 .prose-xl {
   font-size: 1.25rem;
   line-height: 1.8;
@@ -1814,6 +1821,10 @@ video {
 
 .dark\:prose-invert:is(.dark *) :where(a):not(:where([class~="not-prose"],[class~="not-prose"] *)) code {
   color: #38bdf8;
+}
+
+.dark\:prose-invert:is(.dark *) :where(code.language-plaintext):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  background-color: #1f2937;
 }
 
 .open\:pb-5[open] {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,12 @@ module.exports = {
               },
               code: { color: theme('colors.primary.400') },
             },
+            'code.language-plaintext': {
+              fontWeight: 'inherit',
+              padding: theme('spacing.[0.5]'),
+              borderRadius: theme('borderRadius.DEFAULT'),
+              backgroundColor: theme('colors.gray.100'),
+            },
           }
         },
         invert: {
@@ -41,6 +47,9 @@ module.exports = {
                 color: `${theme('colors.primary.400')}`,
               },
               code: { color: theme('colors.primary.400') },
+            },
+            'code.language-plaintext': {
+              backgroundColor:  theme('colors.gray.800'),
             },
           }
         }


### PR DESCRIPTION
Update the `code` style to have the same style as GitHub.

| Before | After |
|---|---|
| <img width="754" alt="image" src="https://github.com/user-attachments/assets/dec1bbe7-3134-4a67-8cc4-f3f0ea9d7105"> | <img width="762" alt="image" src="https://github.com/user-attachments/assets/dfd15000-e780-46ed-a366-39bae730aea7"> |
| <img width="781" alt="image" src="https://github.com/user-attachments/assets/267e0417-f951-4706-9c5d-422adaa78ecf"> | <img width="763" alt="image" src="https://github.com/user-attachments/assets/ab8d81f5-21d8-412e-a147-fe4a7a9f9c11"> | 