### PR TITLE
chore: remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - toshimaru
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - toshimaru
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - toshimaru


### PR DESCRIPTION
## Summary
- remove default reviewers from Dependabot config

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68b4f6ec37c0832b921d8ea3acf8b15b